### PR TITLE
Allow spaces in JAVA_HOME on Windows. Also add the win32 include dire…

### DIFF
--- a/windows/Makefile
+++ b/windows/Makefile
@@ -4,7 +4,7 @@ all: target\classes\wfssl.dll
 OBJECTS = target\alpn.obj target\clientcert.obj target\options.obj target\session.obj target\ssl.obj target\threads.obj target\util.obj
 
 {../libwfssl/src}.c{target}.obj:
-    cl $<  /Fo$@ -I..\libwfssl\include -I$(JAVA_HOME)\include -IC:\OpenSSL-Win64\include /LD /c
+    cl $<  /Fo$@ -I..\libwfssl\include -I"$(JAVA_HOME)\include" -I"$(JAVA_HOME)\include\win32" -IC:\OpenSSL-Win64\include /LD /c
 
 target:
   mkdir target


### PR DESCRIPTION
…ctory for JAVA_HOME.

This was needed for me to build successfully on Windows 7. I was building from the x64 prompt so I'm not certain why the `%JAVA_HOME%\include\win32` directory was needed, but if failed with missing the `jni_md.h` file in that directory without adding it.