### PR TITLE
Added stdint.h include as uint64_t is used in the wfssl.h file

### DIFF
--- a/libwfssl/include/wfssl.h
+++ b/libwfssl/include/wfssl.h
@@ -45,6 +45,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 #include <jni.h>
+#include <stdint.h>
 #include <openssl/crypto.h>
 #include <openssl/pkcs12.h>
 #include <openssl/evp.h>


### PR DESCRIPTION
When I tried to compile this code on RHEL6, I ran into the problem
that uint64_t was not known for wfssl.h file. This MR should fix that.
For some reason I did not run into this when compiling on Fedora 24
(probably because of different header dependencies so stdint.h is
actually included somewhere before already?).
