### PR TITLE
WFLY-7704: enableCipherSuite proper call delegation to sslEngine

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/OpenSSLSocket.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLSocket.java
@@ -201,7 +201,7 @@ public class OpenSSLSocket extends SSLSocket {
 
     @Override
     public void setEnabledCipherSuites(String[] suites) {
-        sslEngine.setEnabledProtocols(suites);
+        sslEngine.setEnabledCipherSuites(suites);
     }
 
     @Override


### PR DESCRIPTION
Fixing calling of incorrect method for the proper one.