### PR TITLE
Separated linux building by architecture.

### DIFF
--- a/combined/pom.xml
+++ b/combined/pom.xml
@@ -83,11 +83,15 @@
             </dependencies>
         </profile>
         <profile>
-            <id>linux</id>
+            <id>linux-i386</id>
             <activation>
                 <os>
                     <family>linux</family>
                 </os>
+                <property>
+                    <name>sun.arch.data.model</name>
+                    <value>32</value>
+                </property>
             </activation>
             <dependencies>
                 <dependency>
@@ -95,6 +99,20 @@
                     <artifactId>wildfly-openssl-linux-i386</artifactId>
                     <version>${project.version}</version>
                 </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>linux-x86_64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                </os>
+                <property>
+                    <name>sun.arch.data.model</name>
+                    <value>64</value>
+                </property>
+            </activation>
+            <dependencies>
                 <dependency>
                     <groupId>org.wildfly.openssl</groupId>
                     <artifactId>wildfly-openssl-linux-x86_64</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -128,11 +128,15 @@
             </dependencies>
         </profile>
         <profile>
-            <id>linux</id>
+            <id>linux-i386</id>
             <activation>
                 <os>
                     <family>linux</family>
                 </os>
+                <property>
+                    <name>sun.arch.data.model</name>
+                    <value>32</value>
+                </property>
             </activation>
             <dependencies>
                 <dependency>
@@ -141,6 +145,20 @@
                     <version>${project.version}</version>
                     <scope>test</scope>
                 </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>linux-x86_64</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                </os>
+                <property>
+                    <name>sun.arch.data.model</name>
+                    <value>64</value>
+                </property>
+            </activation>
+            <dependencies>
                 <dependency>
                     <groupId>org.wildfly.openssl</groupId>
                     <artifactId>wildfly-openssl-linux-x86_64</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,15 +114,34 @@
             </modules>
         </profile>
         <profile>
-            <id>linux</id>
+            <id>linux-i386</id>
+            <activation>
+                <os>
+                    <family>linux</family>
+                    <arch>i386</arch>
+                </os>
+                <property>
+                    <name>sun.arch.data.model</name>
+                    <value>32</value>
+                </property>
+            </activation>
+            <modules>
+                <module>linux-i386</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>linux-x86_64</id>
             <activation>
                 <os>
                     <family>linux</family>
                 </os>
+                <property>
+                    <name>sun.arch.data.model</name>
+                    <value>64</value>
+                </property>
             </activation>
             <modules>
                 <module>linux-x86_64</module>
-                <module>linux-i386</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
Separated build on linux to separate profiles one for 32bit system and
one for 64bit system. The separation is based on system property
sun.arch.data.model