### PR TITLE
Fix compilation on IBM JDK

### DIFF
--- a/libwfssl/src/session.c
+++ b/libwfssl/src/session.c
@@ -224,7 +224,7 @@ jbyteArray getSessionId(JNIEnv *e, SSL_SESSION *session) {
         return NULL;
     }
     bArray = (*e)->NewByteArray(e, len);
-    (*e)->SetByteArrayRegion(e, bArray, 0, len, session_id);
+    (*e)->SetByteArrayRegion(e, bArray, 0, len, (jbyte*)session_id);
     return bArray;
 }
 


### PR DESCRIPTION
There seems to be an inconsistency between the JNI function declarations in Oracle and IBM JDKs for the last arg of SetByteArrayRegion (really, all functions like this).

Oracle v8 uses const jbyte *

void (JNICALL *SetByteArrayRegion)
  (JNIEnv *env, jbyteArray array, jsize start, jsize len, const jbyte *buf);

whereas IBM v8 uses jbyte *

void (JNICALL * SetByteArrayRegion)(JNIEnv *env, jbyteArray array, jsize start, jsize len, jbyte *buf); 

This patch allows for compilation under both the Oracle and the IBM JDKs.
