### PR TITLE
Allow setting of CC, CFLAGS, and LDFLAGS in UNIX Makefiles

### DIFF
--- a/linux-i386/Makefile
+++ b/linux-i386/Makefile
@@ -1,4 +1,4 @@
-
+CC = cc
 SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
 OBJ = $(patsubst %.c, target/%.o, $(SRC))
 
@@ -11,7 +11,7 @@ target/classes/linux-i386:
 	mkdir -p target/classes/linux-i386
 
 target/%.o : ../libwfssl/src/%.c target/classes/linux-i386
-	cc  -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -m32 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -m32 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
 
 target/classes/linux-i386/libwfssl.so: $(OBJ)
-	cc -m32 -shared $(OBJ) -o $@ -Wl,--no-as-needed -ldl
+	$(CC) $(CFLAGS) -m32 -shared $(OBJ) -o $@ $(LDFLAGS) -Wl,--no-as-needed -ldl

--- a/linux-x86_64/Makefile
+++ b/linux-x86_64/Makefile
@@ -1,4 +1,4 @@
-
+CC = cc
 SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
 OBJ = $(patsubst %.c, target/%.o, $(SRC))
 
@@ -11,7 +11,7 @@ target/classes/linux-x86_64:
 	mkdir -p target/classes/linux-x86_64
 
 target/%.o : ../libwfssl/src/%.c target/classes/linux-x86_64
-	cc -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
 
 target/classes/linux-x86_64/libwfssl.so: $(OBJ)
-	cc -shared $(OBJ) -o $@ -Wl,--no-as-needed -ldl
+	$(CC) $(CFLAGS) -shared $(OBJ) -o $@ $(LDFLAGS) -Wl,--no-as-needed -ldl

--- a/macosx-x86_64/Makefile
+++ b/macosx-x86_64/Makefile
@@ -1,4 +1,4 @@
-
+CC = cc
 SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
 OBJ = $(patsubst %.c, target/%.o, $(SRC))
 
@@ -11,7 +11,7 @@ target/classes/macosx-x86_64:
 	mkdir -p target/classes/macosx-x86_64
 
 target/%.o : ../libwfssl/src/%.c target/classes/macosx-x86_64
-	cc -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -c $< -o $@ -I../libwfssl/include
+	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -c $< -o $@ -I../libwfssl/include
 
 target/classes/macosx-x86_64/libwfssl.dylib: $(OBJ)
-	cc -dynamiclib $(OBJ) -o $@
+	$(CC) $(CFLAGS) -dynamiclib $(OBJ) -o $@ $(LDFLAGS)

--- a/solaris-sparcv9/Makefile
+++ b/solaris-sparcv9/Makefile
@@ -1,4 +1,4 @@
-
+CC = gcc
 SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
 OBJ = $(patsubst %.c, target/%.o, $(SRC))
 
@@ -10,25 +10,25 @@ target/classes/solaris-sparcv9:
 	mkdir -p target/classes/solaris-sparcv9
 
 target/alpn.o : ../libwfssl/src/alpn.c target/classes/solaris-sparcv9
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/clientcert.o : ../libwfssl/src/clientcert.c target/classes/solaris-sparcv9
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/options.o : ../libwfssl/src/options.c target/classes/solaris-sparcv9
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/session.o : ../libwfssl/src/session.c target/classes/solaris-sparcv9
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/ssl.o : ../libwfssl/src/ssl.c target/classes/solaris-sparcv9
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/threads.o : ../libwfssl/src/threads.c target/classes/solaris-sparcv9
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/util.o : ../libwfssl/src/util.c target/classes/solaris-sparcv9
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/classes/solaris-sparcv9/libwfssl.so: $(OBJ)
-	gcc -m64 -shared $(OBJ) -o $@ -Wl,--no-as-needed -ldl
+	$(CC) $(CFLAGS) -m64 -shared $(OBJ) -o $@ $(LDFLAGS) -Wl,--no-as-needed -ldl

--- a/solaris-x86_64/Makefile
+++ b/solaris-x86_64/Makefile
@@ -1,4 +1,4 @@
-
+CC = gcc
 SRC = alpn.c clientcert.c options.c session.c ssl.c threads.c util.c
 OBJ = $(patsubst %.c, target/%.o, $(SRC))
 
@@ -10,25 +10,25 @@ target/classes/solaris-x86_64:
 	mkdir -p target/classes/solaris-x86_64
 
 target/alpn.o : ../libwfssl/src/alpn.c target/classes/solaris-x86_64
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/clientcert.o : ../libwfssl/src/clientcert.c target/classes/solaris-x86_64
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/options.o : ../libwfssl/src/options.c target/classes/solaris-x86_64
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/session.o : ../libwfssl/src/session.c target/classes/solaris-x86_64
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/ssl.o : ../libwfssl/src/ssl.c target/classes/solaris-x86_64
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/threads.o : ../libwfssl/src/threads.c target/classes/solaris-x86_64
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/util.o : ../libwfssl/src/util.c target/classes/solaris-x86_64
-	gcc -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
+	$(CC) $(CFLAGS) -m64 -fPIC -c $< -o $@ -I../libwfssl/include -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/solaris
 
 target/classes/solaris-x86_64/libwfssl.so: $(OBJ)
-	gcc -m64 -shared $(OBJ) -o $@ -Wl,--no-as-needed -ldl
+	$(CC) $(CFLAGS) -m64 -shared $(OBJ) -o $@ $(LDFLAGS) -Wl,--no-as-needed -ldl


### PR DESCRIPTION
This patch adds a few standard variables to the UNIX Makefiles, namely, CC, CFLAGS, and LDFLAGS.

In particular, CFLAGS and LDFLAGS are needed to allow the proper compiler and linker flags to be passed when compiling on RHEL. Otherwise, compilation may fail on these Linux distributions.

The Windows Makefiles have been left as-is.