### PR TITLE
[WFSSL-7] Handling of NPE on obtaining PrivateKey from FIPS PKCS11 key manager

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/Messages.java
+++ b/java/src/main/java/org/wildfly/openssl/Messages.java
@@ -65,6 +65,7 @@ public class Messages {
     private static final String MSG33 = formatCode(33);
     private static final String MSG34 = formatCode(34);
     private static final String MSG35 = formatCode(35);
+    private static final String MSG36 = formatCode(36);
 
     private static String formatCode(int i) {
         return CODE + new DecimalFormat("0000").format(i);
@@ -205,5 +206,8 @@ public class Messages {
     }
     public String streamIsClosed() {
         return interpolate(MSG35);
+    }
+    public String unableToObtainPrivateKey() {
+        return interpolate(MSG36);
     }
 }

--- a/java/src/main/java/org/wildfly/openssl/OpenSSLContextSPI.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLContextSPI.java
@@ -206,7 +206,11 @@ public abstract class OpenSSLContextSPI extends SSLContextSpi {
                                 LOG.fine("Using alias " + alias + " for " + algorithm);
                             }
                             StringBuilder sb = new StringBuilder(rsa ? BEGIN_RSA_CERT : BEGIN_DSA_CERT);
-                            sb.append(Base64.getMimeEncoder(64, new byte[]{'\n'}).encodeToString(key.getEncoded()));
+                            byte[] encodedPrivateKey = key.getEncoded();
+                            if (encodedPrivateKey == null) {
+                                throw new KeyManagementException(Messages.MESSAGES.unableToObtainPrivateKey());
+                            }
+                            sb.append(Base64.getMimeEncoder(64, new byte[]{'\n'}).encodeToString(encodedPrivateKey));
                             sb.append(rsa ? END_RSA_CERT : END_DSA_CERT);
                             SSL.getInstance().setCertificate(ctx, certificate.getEncoded(), sb.toString().getBytes(StandardCharsets.US_ASCII), rsa ? SSL.SSL_AIDX_RSA : SSL.SSL_AIDX_DSA);
                             break;

--- a/java/src/main/resources/org/wildfly/openssl/OpenSSLMessages.properties
+++ b/java/src/main/resources/org/wildfly/openssl/OpenSSLMessages.properties
@@ -50,3 +50,4 @@ WFOPENSSL0032=Buffer overflow
 WFOPENSSL0033=Buffer underflow
 WFOPENSSL0034=Unsupported address type
 WFOPENSSL0035=Stream is closed
+WFOPENSSL0036=Unable to obtain encoded private key - maybe you are trying to use OpenSSL with FIPS PKCS11 key manager?


### PR DESCRIPTION
Added handling of NPE documented in JBEAP-10396.
https://issues.jboss.org/browse/WFSSL-7
https://issues.jboss.org/browse/JBEAP-10396