### PR TITLE
Fix build on MacOS with Java 8

### DIFF
--- a/macosx-x86_64/Makefile
+++ b/macosx-x86_64/Makefile
@@ -11,7 +11,7 @@ target/classes/macosx-x86_64:
 	mkdir -p target/classes/macosx-x86_64
 
 target/%.o : ../libwfssl/src/%.c target/classes/macosx-x86_64
-	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -c $< -o $@ -I../libwfssl/include
+	$(CC) $(CFLAGS) -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -c $< -o $@ -I../libwfssl/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin
 
 target/classes/macosx-x86_64/libwfssl.dylib: $(OBJ)
 	$(CC) $(CFLAGS) -dynamiclib $(OBJ) -o $@ $(LDFLAGS)


### PR DESCRIPTION
While building the project on MacOS (Sierra) with Java 8:

```
java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
```

the build fails with:

```
[INFO] --- exec-maven-plugin:1.5.0:exec (default) @ wildfly-openssl-macosx-x86_64 ---
mkdir -p target/classes/macosx-x86_64
cc  -Werror -Wall -Wmissing-prototypes -Wstrict-prototypes -Wmissing-declarations -Wpointer-arith -std=c89 -Wdeclaration-after-statement -Wformat -Wformat-security -Wunused -Wno-unknown-pragmas -c ../libwfssl/src/alpn.c -o target/alpn.o -I../libwfssl/include
In file included from ../libwfssl/src/alpn.c:2:
../libwfssl/include/wfssl.h:41:10: fatal error: 'jni.h' file not found
#include <jni.h>
         ^
1 error generated.
make: *** [target/alpn.o] Error 1
[ERROR] Command execution failed.
org.apache.commons.exec.ExecuteException: Process exited with an error: 2 (Exit value: 2)
```

The commit in this PR includes the `${JAVA_HOME}/include` and `${JAVA_HOME}/include/darwin` (which is where the `jni.h` and `jni_md.h` reside) in the compilation path. Adding this got me past the compilation failures and the build succeeded.

 