### PR TITLE
Fix ByteBufferUtil to make it work in Java 9

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/ByteBufferUtils.java
+++ b/java/src/main/java/org/wildfly/openssl/ByteBufferUtils.java
@@ -17,28 +17,11 @@
 
 package org.wildfly.openssl;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import org.wildfly.openssl.util.DirectByteBufferDeallocator;
+
 import java.nio.ByteBuffer;
 
 public class ByteBufferUtils {
-
-    private static final Method cleanerMethod;
-    private static final Method cleanMethod;
-
-    static {
-        try {
-            ByteBuffer tempBuffer = ByteBuffer.allocateDirect(0);
-            cleanerMethod = tempBuffer.getClass().getMethod("cleaner");
-            cleanerMethod.setAccessible(true);
-            Object cleanerObject = cleanerMethod.invoke(tempBuffer);
-            cleanMethod = cleanerObject.getClass().getMethod("clean");
-            cleanMethod.invoke(cleanerObject);
-        } catch (IllegalAccessException | IllegalArgumentException
-                | InvocationTargetException | NoSuchMethodException | SecurityException e) {
-            throw new ExceptionInInitializerError(e);
-        }
-    }
 
     private ByteBufferUtils() {
         // Hide the default constructor since this is a utility class.
@@ -51,8 +34,8 @@ public class ByteBufferUtils {
      * while it was in 'read from' mode.
      *
      * @param in Buffer to expand
-     * @return   The expanded buffer with any data from the input buffer copied
-     *           in to it
+     * @return The expanded buffer with any data from the input buffer copied
+     * in to it
      */
     public static ByteBuffer expand(ByteBuffer in) {
         return expand(in, in.capacity() * 2);
@@ -64,11 +47,11 @@ public class ByteBufferUtils {
      * Buffers are assumed to be in 'write to' mode since there would be no need
      * to expand a buffer while it was in 'read from' mode.
      *
-     * @param in        Buffer to expand
-     * @param newSize   The size t which the buffer should be expanded
-     * @return          The expanded buffer with any data from the input buffer
-     *                  copied in to it or the original buffer if there was no
-     *                  need for expansion
+     * @param in      Buffer to expand
+     * @param newSize The size t which the buffer should be expanded
+     * @return The expanded buffer with any data from the input buffer
+     * copied in to it or the original buffer if there was no
+     * need for expansion
      */
     public static ByteBuffer expand(ByteBuffer in, int newSize) {
         if (in.capacity() >= newSize) {
@@ -95,13 +78,8 @@ public class ByteBufferUtils {
         return out;
     }
 
-    public static void cleanDirectBuffer(ByteBuffer buf) {
-        try {
-            cleanMethod.invoke(cleanerMethod.invoke(buf));
-        } catch (IllegalAccessException | IllegalArgumentException
-                | InvocationTargetException | SecurityException e) {
-            // Ignore
-        }
+    public static void cleanDirectBuffer(final ByteBuffer buf) {
+        DirectByteBufferDeallocator.free(buf);
     }
 
 }

--- a/java/src/main/java/org/wildfly/openssl/Messages.java
+++ b/java/src/main/java/org/wildfly/openssl/Messages.java
@@ -66,6 +66,8 @@ public class Messages {
     private static final String MSG34 = formatCode(34);
     private static final String MSG35 = formatCode(35);
     private static final String MSG36 = formatCode(36);
+    private static final String MSG37 = formatCode(37);
+    private static final String MSG38 = formatCode(38);
 
     private static String formatCode(int i) {
         return CODE + new DecimalFormat("0000").format(i);
@@ -209,5 +211,11 @@ public class Messages {
     }
     public String unableToObtainPrivateKey() {
         return interpolate(MSG36);
+    }
+    public String directBufferDeallocatorInitializationFailed () {
+        return interpolate(MSG37);
+    }
+    public String directBufferDeallocationFailed() {
+        return interpolate(MSG38);
     }
 }

--- a/java/src/main/java/org/wildfly/openssl/util/DirectByteBufferDeallocator.java
+++ b/java/src/main/java/org/wildfly/openssl/util/DirectByteBufferDeallocator.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+package org.wildfly.openssl.util;
+
+import org.wildfly.openssl.Messages;
+import sun.misc.Unsafe;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.security.PrivilegedAction;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * {@link DirectByteBufferDeallocator} Utility class used to free direct buffer memory.
+ */
+public final class DirectByteBufferDeallocator {
+
+    private static final Logger logger = Logger.getLogger(DirectByteBufferDeallocator.class.getName());
+
+    private static final boolean SUPPORTED;
+    private static final Method cleaner;
+    private static final Method cleanerClean;
+
+    private static final Unsafe UNSAFE;
+
+
+    static {
+        String versionString = System.getProperty("java.specification.version");
+        if (versionString.startsWith("1.")) {
+            versionString = versionString.substring(2);
+        }
+        int version = Integer.parseInt(versionString);
+
+        Method tmpCleaner = null;
+        Method tmpCleanerClean = null;
+        boolean supported;
+        Unsafe tmpUnsafe = null;
+        if (version < 9) {
+            try {
+                tmpCleaner = Class.forName("java.nio.DirectByteBuffer").getMethod("cleaner");
+                tmpCleaner.setAccessible(true);
+                tmpCleanerClean = Class.forName("sun.misc.Cleaner").getMethod("clean");
+                tmpCleanerClean.setAccessible(true);
+                supported = true;
+            } catch (Throwable t) {
+                logger.log(Level.WARNING, Messages.MESSAGES.directBufferDeallocatorInitializationFailed(), t);
+                supported = false;
+            }
+        } else {
+            tmpUnsafe = getUnsafe();
+            try {
+                tmpCleanerClean = tmpUnsafe.getClass().getDeclaredMethod("invokeCleaner", ByteBuffer.class);
+                tmpCleanerClean.setAccessible(true);
+                supported = true;
+            } catch (Throwable t) {
+                logger.log(Level.WARNING, Messages.MESSAGES.directBufferDeallocatorInitializationFailed(), t);
+                supported = false;
+            }
+        }
+        SUPPORTED = supported;
+        cleaner = tmpCleaner;
+        cleanerClean = tmpCleanerClean;
+        UNSAFE = tmpUnsafe;
+
+    }
+
+    private DirectByteBufferDeallocator() {
+        // Utility Class
+    }
+
+    /**
+     * Attempts to deallocate the underlying direct memory.
+     * This is a no-op for buffers where {@link ByteBuffer#isDirect()} returns false.
+     *
+     * @param buffer to deallocate
+     */
+    public static void free(ByteBuffer buffer) {
+        if (SUPPORTED && buffer != null && buffer.isDirect()) {
+            try {
+                if (UNSAFE != null) {
+                    //use the JDK9 method
+                    cleanerClean.invoke(UNSAFE, buffer);
+                } else {
+                    Object cleaner = DirectByteBufferDeallocator.cleaner.invoke(buffer);
+                    cleanerClean.invoke(cleaner);
+                }
+            } catch (Throwable t) {
+                logger.log(Level.WARNING, Messages.MESSAGES.directBufferDeallocationFailed(), t);
+            }
+        }
+    }
+
+    private static Unsafe getUnsafe() {
+        if (System.getSecurityManager() != null) {
+            return new PrivilegedAction<Unsafe>() {
+                public Unsafe run() {
+                    return getUnsafe0();
+                }
+            }.run();
+        }
+        return getUnsafe0();
+    }
+
+    private static Unsafe getUnsafe0() {
+        try {
+            Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
+            theUnsafe.setAccessible(true);
+            return (Unsafe) theUnsafe.get(null);
+        } catch (Throwable t) {
+            throw new RuntimeException("JDK did not allow accessing unsafe", t);
+        }
+    }
+}

--- a/java/src/main/resources/org/wildfly/openssl/OpenSSLMessages.properties
+++ b/java/src/main/resources/org/wildfly/openssl/OpenSSLMessages.properties
@@ -51,3 +51,5 @@ WFOPENSSL0033=Buffer underflow
 WFOPENSSL0034=Unsupported address type
 WFOPENSSL0035=Stream is closed
 WFOPENSSL0036=Unable to obtain encoded private key - maybe you are trying to use OpenSSL with FIPS PKCS11 key manager?
+WFOPENSSL0037=Failed to initialize DirectByteBufferDeallocator
+WFOPENSSL0038=Failed to free direct buffer


### PR DESCRIPTION
@stuartwdouglas, when trying to build the project with Java 9, I ran into runtime exceptions (reproducible in the existing tests) in the ByteBufferUtils which tries to get a cleaner to clean the direct bytebuffers. Exceptions of the form:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.wildfly.openssl.ByteBufferUtils (file:/opt/wildfly/wildfly-openssl/java/target/classes/) to method java.nio.DirectByteBuffer.cleaner()
WARNING: Please consider reporting this to the maintainers of org.wildfly.openssl.ByteBufferUtils
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.368 sec <<< FAILURE! - in org.wildfly.openssl.ALPNTest
testALPN(org.wildfly.openssl.ALPNTest)  Time elapsed: 0.27 sec  <<< ERROR!
java.lang.ExceptionInInitializerError: null
	at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:361)
	at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:589)
	at java.base/java.lang.reflect.Method.invoke(Method.java:556)
	at org.wildfly.openssl.ByteBufferUtils.<clinit>(ByteBufferUtils.java:36)
	at org.wildfly.openssl.OpenSSLEngine.readEncryptedData(OpenSSLEngine.java:365)
	at org.wildfly.openssl.OpenSSLEngine.wrap(OpenSSLEngine.java:471)
	at java.base/javax.net.ssl.SSLEngine.wrap(SSLEngine.java:471)
	at org.wildfly.openssl.OpenSSLSocket.write(OpenSSLSocket.java:510)
	at org.wildfly.openssl.OpenSSLSocket.write(OpenSSLSocket.java:541)
	at org.wildfly.openssl.OpenSSLOutputStream.write(OpenSSLOutputStream.java:51)
	at org.wildfly.openssl.ALPNTest.testALPN(ALPNTest.java:57)

```
The commit in this pull request fixes this. The change in this PR works both in Java 8 and Java 9. The `DirectByteBufferDeallocator` class that this commit introduces is borrowed from its counterpart in the Undertow project.

P.S: This does get us past the ByteBufferUtil issue, but the `ClientSessionTest` continues to fail in Java 9, due to an unrelated issue. The tests that fail are the session resumption tests:

```
Failed tests: 
  ClientSessionTest.testJsse:54->testSessionId:199 arrays first differed at element [0]; expected:<-35> but was:<120>
  ClientSessionTest.testSessionTimeout:81 arrays first differed at element [0]; expected:<104> but was:<-94>
  ClientSessionTest.testSessionSize:143 arrays first differed at element [0]; expected:<14> but was:<94>

```
The failures _don't_ appear to be due to some issue in the tests nor a bug in WildFly OpenSSL. Instead, it appears that SSL session resumption for any SSL protocol lesser than `TLSv1.2` has regressed  within the JRE itself. I was able to narrow it down to a specific code in Java 9 and have reported that issue in OpenJDK and is currently being tracked at https://bugs.openjdk.java.net/browse/JDK-8190917.

So for now, you will continue to see test failures against Java 9.