### PR TITLE
Propogate back EOF from read() on OpenSSLSocket

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/OpenSSLSocket.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLSocket.java
@@ -384,9 +384,9 @@ public class OpenSSLSocket extends SSLSocket {
     }
 
     public int read() throws IOException {
-        byte[] b = new byte[1];
-        read(b);
-        return b[0] & 0xFF;
+        final byte[] b = new byte[1];
+        final int numRead = read(b);
+        return numRead == -1 ? -1 : (b[0] & 0xFF);
     }
 
     public int read(byte[] b, int off, int len) throws IOException {


### PR DESCRIPTION
Hi @stuartwdouglas, the commit here fixes the issue reported here https://github.com/wildfly/wildfly-openssl/issues/31

The change propagates `-1` back from the `OpenSSLSocket#read()` upon EOF.