### PR TITLE
Fixed org.wildfly.checkstyle version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.org.wildfly.checkstyle>1.0.5.Final-SNAPSHOT</version.org.wildfly.checkstyle>
+        <version.org.wildfly.checkstyle>1.0.5.Final</version.org.wildfly.checkstyle>
 
         <openssl.path></openssl.path>
         <cmake.generator>Unix Makefiles</cmake.generator>


### PR DESCRIPTION
 - This version has been accidentally updated during `wildfly-openssl`
   version bump by 9a20fc6 commit from `1.0.4.Final`. As `1.0.5.Final`
   has been already released, using this version instead.

As version of `wildfly-openssl` matches `checkstyle` version again. We need to watch out what versions are bumped during the next release.