### PR TITLE
Fix JVM crash during client SSL session invalidation

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/OpenSSLClientSessionContext.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLClientSessionContext.java
@@ -84,9 +84,9 @@ public final class OpenSSLClientSessionContext extends OpenSSLSessionContext {
             final ClientSessionInfo foundSessionPtr = getCacheValue(key);
             if (foundSessionPtr != null) {
                 if(getSession(foundSessionPtr.sessionId) != null) {
-                    removeCacheEntry(key, true);
+                    removeCacheEntry(key);
                 } else {
-                    removeCacheEntry(key, false);
+                    removeCacheEntry(key);
                 }
             }
             final long sessionPointer = SSL.getInstance().getSession(ssl);
@@ -102,7 +102,7 @@ public final class OpenSSLClientSessionContext extends OpenSSLSessionContext {
             final ClientSessionInfo foundSessionPtr = getCacheValue(key);
             if (foundSessionPtr != null) {
                 if(getSession(foundSessionPtr.sessionId) == null) {
-                    removeCacheEntry(key, false);
+                    removeCacheEntry(key);
                 } else {
                     SSL.getInstance().setSession(ssl, foundSessionPtr.session);
                 }
@@ -118,7 +118,7 @@ public final class OpenSSLClientSessionContext extends OpenSSLSessionContext {
                 for (int i = 0; i < removeSize; i++) {
                     final CacheEntry oldest = accessQueue.poll();
                     if (oldest != null) {
-                        removeCacheEntry(oldest.key(), true);
+                        removeCacheEntry(oldest.key());
                     } else {
                         // No need to continue as there are no more entries
                         break;
@@ -142,7 +142,7 @@ public final class OpenSSLClientSessionContext extends OpenSSLSessionContext {
                 // Remove the oldest entry
                 final CacheEntry oldest = accessQueue.poll();
                 if (oldest != value) {
-                    removeCacheEntry(oldest.key(), true);
+                    removeCacheEntry(oldest.key());
                 }
             }
         }
@@ -156,7 +156,7 @@ public final class OpenSSLClientSessionContext extends OpenSSLSessionContext {
         if (timeout > 0) {
             long expires = cacheEntry.getTime() + (timeout * 1000);
             if (System.currentTimeMillis() > expires) {
-                removeCacheEntry(key, true);
+                removeCacheEntry(key);
                 return null;
             }
         }
@@ -168,7 +168,7 @@ public final class OpenSSLClientSessionContext extends OpenSSLSessionContext {
         return cacheEntry.getValue();
     }
 
-    private ClientSessionInfo removeCacheEntry(final ClientSessionKey key, boolean sessionStillValid) {
+    private ClientSessionInfo removeCacheEntry(final ClientSessionKey key) {
         CacheEntry remove = cache.remove(key);
         if (remove != null) {
             Object old = remove.clearToken();
@@ -176,8 +176,8 @@ public final class OpenSSLClientSessionContext extends OpenSSLSessionContext {
                 accessQueue.removeToken(old);
             }
             final ClientSessionInfo result =  remove.getValue();
-            if (result != null && sessionStillValid) {
-                SSL.getInstance().invalidateSession(result.session);
+            if (result != null) {
+                invalidateIfPresent(result.sessionId);
             }
             return result;
         } else {

--- a/java/src/main/java/org/wildfly/openssl/OpenSSLClientSessionContext.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLClientSessionContext.java
@@ -101,10 +101,15 @@ public final class OpenSSLClientSessionContext extends OpenSSLSessionContext {
             // set with the session pointer from the found session
             final ClientSessionInfo foundSessionPtr = getCacheValue(key);
             if (foundSessionPtr != null) {
-                if(getSession(foundSessionPtr.sessionId) == null) {
+                final OpenSSlSession existingSession = getOpenSSlSession(foundSessionPtr.sessionId);
+                if(existingSession == null) {
                     removeCacheEntry(key);
                 } else {
-                    SSL.getInstance().setSession(ssl, foundSessionPtr.session);
+                    synchronized (existingSession) {
+                        if (existingSession.isValid()) {
+                            SSL.getInstance().setSession(ssl, foundSessionPtr.session);
+                        }
+                    }
                 }
             }
         }

--- a/java/src/main/java/org/wildfly/openssl/OpenSSLSessionContext.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLSessionContext.java
@@ -46,6 +46,10 @@ abstract class OpenSSLSessionContext implements SSLSessionContext {
         return sessions.get(new Key(bytes));
     }
 
+    OpenSSlSession getOpenSSlSession(final byte[] sessionId) {
+        return sessions.get(new Key(sessionId));
+    }
+
     @Override
     public Enumeration<byte[]> getIds() {
         final Iterator<Key> keys = new HashSet<>(sessions.keySet()).iterator();

--- a/java/src/main/java/org/wildfly/openssl/OpenSSLSessionContext.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLSessionContext.java
@@ -83,6 +83,20 @@ abstract class OpenSSLSessionContext implements SSLSessionContext {
         this.sessions.remove(new Key(session));
     }
 
+    /**
+     * Removes a cached session, represented by the {@code sessionId} and
+     * {@link SSLSession#invalidate() invalidates} it
+     *
+     * @param sessionId The session id
+     */
+    void invalidateIfPresent(final byte[] sessionId) {
+        final OpenSSlSession session = this.sessions.remove(new Key(sessionId));
+        if (session == null) {
+            return;
+        }
+        session.invalidate();
+    }
+
     synchronized void sessionCreatedCallback(long ssl, long session, byte[] sessionId) {
         final OpenSSlSession openSSlSession = new OpenSSlSession(true, this);
         openSSlSession.initialised(session, ssl, sessionId);


### PR DESCRIPTION
@stuartwdouglas, the commit here fixes a issue reported here https://github.com/wildfly/wildfly-openssl/issues/36 where the JVM consistently crashes due to a racy invalidation of the SSL client session. The commit includes a test case which reproduces this issue (in the absence of the fix in this PR) that causes the JVM to crash with:

```
malloc: *** error for object ...: pointer being freed was not allocated
```
The change in this commit involves removing the possibility of a race condition between the session cache management and invalidation, by letting the `OpenSSlSession#invalidate()` be the sole responsible authority for invalidating the session since it already has the necessary synchronization techniques to prevent the race conditions.

P.S: The referenced issue, seems to indicate there's one other different (memory leak?) issue in this area. That one I haven't yet understood and haven't attempted a fix for.


