### PR TITLE
OpenSSL 1.1.0 - Enable TLS_DHE_DSS_WITH_AES_128_CBC_SHA for DSA test to pass

### DIFF
--- a/java/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketDSATest.java
+++ b/java/src/test/java/org/wildfly/openssl/BasicOpenSSLSocketDSATest.java
@@ -73,6 +73,7 @@ public class BasicOpenSSLSocketDSATest extends AbstractOpenSSLTest {
             final SSLContext sslContext = SSLTestUtils.createClientDSASSLContext("openssl.TLSv1");
             InetSocketAddress socketAddress = (InetSocketAddress) SSLTestUtils.createSocketAddress();
             final SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket(socketAddress.getAddress(), socketAddress.getPort());
+            socket.setEnabledCipherSuites(new String[] {"TLS_DHE_DSS_WITH_AES_128_CBC_SHA"});
             socket.getOutputStream().write("hello world".getBytes(StandardCharsets.US_ASCII));
             socket.getOutputStream().flush();
             byte[] data = new byte[100];


### PR DESCRIPTION
@stuartwdouglas, I was just testing against the 1.1.0 release of OpenSSL:
```
/usr/local/opt/openssl@1.1/bin/openssl version
OpenSSL 1.1.0f  25 May 2017
```
and the `BasicOpenSSLSocketDSATest#basicOpenSSLTest2` kept failing with:

```
javax.net.ssl.SSLHandshakeException: no cipher suites in common
	at sun.security.ssl.Handshaker.checkThrown(Handshaker.java:1478)
	at sun.security.ssl.SSLEngineImpl.checkTaskThrown(SSLEngineImpl.java:535)
	at sun.security.ssl.SSLEngineImpl.writeAppRecord(SSLEngineImpl.java:1214)
	at sun.security.ssl.SSLEngineImpl.wrap(SSLEngineImpl.java:1186)
	at javax.net.ssl.SSLEngine.wrap(SSLEngine.java:469)
	at org.wildfly.openssl.EchoRunnable.lambda$run$0(EchoRunnable.java:92)
	at java.lang.Thread.run(Thread.java:748)
Caused by: javax.net.ssl.SSLHandshakeException: no cipher suites in common
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:192)
	at sun.security.ssl.SSLEngineImpl.fatal(SSLEngineImpl.java:1666)
	at sun.security.ssl.Handshaker.fatalSE(Handshaker.java:304)
	at sun.security.ssl.Handshaker.fatalSE(Handshaker.java:292)
	at sun.security.ssl.ServerHandshaker.chooseCipherSuite(ServerHandshaker.java:1045)
	at sun.security.ssl.ServerHandshaker.clientHello(ServerHandshaker.java:741)
	at sun.security.ssl.ServerHandshaker.processMessage(ServerHandshaker.java:224)
	at sun.security.ssl.Handshaker.processLoop(Handshaker.java:1026)
	at sun.security.ssl.Handshaker$1.run(Handshaker.java:966)
	at sun.security.ssl.Handshaker$1.run(Handshaker.java:963)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.security.ssl.Handshaker$DelegatedTask.run(Handshaker.java:1416)
	at org.wildfly.openssl.EchoRunnable.lambda$run$0(EchoRunnable.java:100)
	... 1 more
```

The commit here explicitly enables the `TLS_DHE_DSS_WITH_AES_128_CBC_SHA` on the client socket (which is backed by OpenSSL provider), so that this cipher gets chosen during the handshake. With this change, the test passes both against 1.0 and 1.1.0 of OpenSSL.

