### PR TITLE
Conditionally disable "extended master secret" extension in tests

### DIFF
--- a/java/src/test/java/org/wildfly/openssl/AbstractOpenSSLTest.java
+++ b/java/src/test/java/org/wildfly/openssl/AbstractOpenSSLTest.java
@@ -37,6 +37,15 @@ public class AbstractOpenSSLTest {
                 System.setProperty("javax.net.ssl.trustStore", "java/src/test/resources/client.truststore");
                 System.setProperty("javax.net.ssl.keyStorePassword", "password");
             }
+            final String openSSLVersion = SSL.getInstance().version();
+            // very crude (but acceptable) way to check the version
+            if (openSSLVersion.contains("1.0.2")) {
+                // 1.0.2 doesn't support "Extended master secret" extension, which is enabled in
+                // Java by default. here we disable that extension on the Java side to allow
+                // session resumption tests to pass
+                // @see http://www.oracle.com/technetwork/java/javase/8u161-relnotes-4021379.html#JDK-8148421
+                System.setProperty("jdk.tls.useExtendedMasterSecret", "false");
+            }
         }
     }
 


### PR DESCRIPTION
Hi @stuartwdouglas, the commit here disables the extended master secret extension that got enabled in recent Java releases (including an update to JDK 8). This causes test failures out of the box while building the project for any Java version if run against 1.0.2 of OpenSSL, as noted here https://github.com/wildfly/wildfly-openssl/issues/45

The commit here disables this extension only in the tests, if OpenSSL 1.0.2 is used. This should give a better out of the box experience when building against OpenSSL 1.0.2.
