### PR TITLE
Close sockets on receiving exceptions during SSL runHandshake phase.

### DIFF
--- a/java/src/main/java/org/wildfly/openssl/OpenSSLSocket.java
+++ b/java/src/main/java/org/wildfly/openssl/OpenSSLSocket.java
@@ -349,7 +349,11 @@ public class OpenSSLSocket extends SSLSocket {
                                 }
 
                         }
-                    } finally {
+                    } catch (IOException | RuntimeException e) {
+                        this.close();
+                        throw e;
+                    }
+                    finally {
                         if(freeIndirect) {
                             indirectPooled.close();
                         }


### PR DESCRIPTION
Without this, it may leak sockets that hold the connection until the server decides to kill it based on its idle channel configuration.

Possible reasons this may arise are data mangling over the wire, bad certificate fingerprint,etc - these issues result in SSL handshake failure at the 'unwrap' phase of OpenSSLEngine, which gets thrown all the way up without the OpenSSLSocket getting a chance to close it gracefully.

If enough sockets are leaked, it may result in serious issues like denial of service.